### PR TITLE
Add RWD promotion

### DIFF
--- a/src/components/features/Promotions/Promotions.module.scss
+++ b/src/components/features/Promotions/Promotions.module.scss
@@ -117,4 +117,25 @@
     .twoPromoBoxes {
         flex: 50%;
     }
+    @media (max-width: 1000px) {
+        .row {
+          display: flex;
+          flex-direction: column;
+          min-width: 1000px;
+        }
+        .bigSquare {
+          min-width: 700px;
+        }
+      }
+
+      @media (max-width: 768px) {
+        .row {
+            display: flex;
+            flex-direction: column;
+            min-width: 768px;
+          }
+          .bigSquare {
+            min-width: 500px;
+          }
+      }
 }


### PR DESCRIPTION
Zadaniem jest stworzenie wersji mobilnych sekcji "Promocje". Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 

Na szerokościach, gdzie trzy boxy nie mieszczą się obok siebie, należy ułożyć je jeden pod drugim (największy na górze, pod nim dwa mniejsze).