### PR TITLE
Wdp-66

### DIFF
--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -100,13 +100,6 @@ class NewFurniture extends React.Component {
             </div>
           </Swipeable>
 
-          <div className='row'>
-            {categoryProducts.slice(activePage * 8, (activePage + 1) * 8).map(item => (
-              <div key={item.id} className='col-3'>
-                <ProductBox {...item} />
-              </div>
-            ))}
-          </div>
           {compared > 0 ? <ComparedProductsBox /> : ''}
         </div>
       </div>

--- a/src/components/features/NewFurniture/NewFurniture.module.scss
+++ b/src/components/features/NewFurniture/NewFurniture.module.scss
@@ -33,6 +33,7 @@
 
     .menu {
       text-align: center;
+      cursor: pointer;
       ul {
         margin: 0;
         padding: 0;

--- a/src/components/features/NewFurniture/NewFurniture.module.scss
+++ b/src/components/features/NewFurniture/NewFurniture.module.scss
@@ -32,6 +32,7 @@
     }
 
     .menu {
+      cursor: pointer;
       text-align: center;
       cursor: pointer;
       ul {


### PR DESCRIPTION
Po zmianie plików oraz zmiany wersji Bootstrapa nasz render New Furniture przestał działać prawidłowo. 

Sprawdzając compontent NewFurniture.js oraz jego zachowanie na stronie zauważyłem, że lista produktów wyświetla się dwa razy. Dlatego też usunąłem diva z categoryProducts.
Dodałem również cursor: pointer do menu. 