### PR TITLE
add styles to mobile resolution of FurnitureGalleryTab and FurnitureG…

### DIFF
--- a/src/components/features/FurnitureGallery/FurnitureGallery.js
+++ b/src/components/features/FurnitureGallery/FurnitureGallery.js
@@ -5,7 +5,6 @@ import { getProductById } from '../../../redux/productsRedux';
 import { useState } from 'react';
 import TabContent from './FurnitureGalleryTabContent/FurnitureGalleryTabContent';
 
-
 import {
   getFeaturedProductsId,
   getSaleOffProductsId,
@@ -54,7 +53,7 @@ const FurnitureGallery = () => {
     <div className={styles.root}>
       <div className='container'>
         <div className='row'>
-          <div className='col-6'>
+          <div className='col-md-6 '>
             <div>
               <div className={styles.header}>
                 <h4>FURNITURE GALLERY</h4>
@@ -129,7 +128,7 @@ const FurnitureGallery = () => {
               </div>
             </div>
           </div>
-          <div className='col-6'>
+          <div className='col-md-6 '>
             <div className={styles.image}>
               <img
                 src={`/${rightSideProduct.picture}`}

--- a/src/components/features/FurnitureGallery/FurnitureGallery.module.scss
+++ b/src/components/features/FurnitureGallery/FurnitureGallery.module.scss
@@ -1,5 +1,5 @@
 @import "../../../styles/settings.scss";
-
+@import '../../../styles/media-queries.scss';
 .root {
   margin: 30px 0;
   .header {
@@ -72,6 +72,7 @@
       top: 45%;
       left: 10%;
     }
+
   }
   .tabs {
     border: 1px solid $furniture-gallery-gray-medium-dark;
@@ -176,4 +177,21 @@
 
 .fade-in {
   opacity: 1;
+}
+
+@media screen and (max-width: 767px) {
+  .root {
+    .image{
+      display: none;
+    }
+  }
+}
+@media screen and (max-width: 471px) {
+  .root {
+    .tabs {
+      p {
+        font-size: 12px
+      }
+    }
+  }
 }

--- a/src/components/features/FurnitureGallery/FurnitureGalleryTabContent/FurnitureGalleryTabContent.js
+++ b/src/components/features/FurnitureGallery/FurnitureGalleryTabContent/FurnitureGalleryTabContent.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import ProductStars from '../../ProductStars/ProductStars';
 import styles from './FurnitureGalleryTabContent.module.scss';
 import Button from '../../../common/Button/Button';
@@ -34,6 +34,7 @@ const TabContent = ({ productsDataId }) => {
   const activeGalleryItemId = useSelector(state => getActiveGalleryItem(state));
   const item = useSelector(state => getProductById(state, activeGalleryItemId));
   const viewport = useSelector(state => getViewport(state));
+  const sliderContainerRef = useRef(null);
 
   const dispatch = useDispatch();
   const sliderItems = useSelector(state => getByIdArray(state, productsDataId));
@@ -49,14 +50,14 @@ const TabContent = ({ productsDataId }) => {
   }, [dispatch, productsDataId]);
 
   useEffect(() => {
-    if (viewport === 'desktop') {
-      setVisibleSlides(6);
-    } else if (viewport === 'tablet') {
-      setVisibleSlides(4);
-    } else if (viewport === 'mobile') {
-      setVisibleSlides(2);
+    if (sliderContainerRef.current) {
+      const sliderContainerWidth = sliderContainerRef.current.offsetWidth;
+      const sliderItemWidth = 90;
+      const maxVisibleSlides = Math.floor(sliderContainerWidth / sliderItemWidth);
+
+      setVisibleSlides(Math.min(maxVisibleSlides, sliderItems.length));
     }
-  }, [viewport]);
+  }, [sliderContainerRef, sliderItems, viewport]);
 
   useEffect(() => {
     dispatch(setActiveGalleryItem(productsDataId[0]));
@@ -65,7 +66,6 @@ const TabContent = ({ productsDataId }) => {
 
   const currency = useSelector(state => state.currency.currency);
   const conversionRates = useSelector(state => state.currency.conversionRates);
-
 
   const handleStarClick = clickedStars => {
     setSelectedStars(clickedStars);
@@ -102,7 +102,6 @@ const TabContent = ({ productsDataId }) => {
     }, 500);
   };
 
-
   const comparedProducts = useSelector(state => getAllCompared(state));
   const compareCount = useSelector(state => getCountCompared(state));
 
@@ -110,7 +109,6 @@ const TabContent = ({ productsDataId }) => {
     const rate = conversionRates[currency];
     return item.price * rate;
   };
-
 
   const onCompareClick = evt => {
     evt.preventDefault();
@@ -223,7 +221,7 @@ const TabContent = ({ productsDataId }) => {
             </Button>
           </div>
         </div>
-        <div className={styles.furnitureGallerySlider}>
+        <div className={styles.furnitureGallerySlider} ref={sliderContainerRef}>
           <div className={styles.row}>
             <button onClick={handlePrevClick}>&#60;</button>
             <div className={styles.slider}>{renderSliderImages()}</div>

--- a/src/components/features/FurnitureGallery/FurnitureGalleryTabContent/FurnitureGalleryTabContent.module.scss
+++ b/src/components/features/FurnitureGallery/FurnitureGalleryTabContent/FurnitureGalleryTabContent.module.scss
@@ -1,11 +1,17 @@
 @import "../../../../styles/settings.scss";
 
 .root {
+  .TabContent {
+    position: relative;
+    height: 500px;
+  }
   .furnitureGallerySlider {
     margin-bottom: 10px;
+    width: 100%;
     .row {
       height: 90px;
       display: flex;
+      flex-wrap: nowrap;
       flex-direction: row;
       justify-content: space-between;
       align-items: center;
@@ -24,6 +30,8 @@
         flex-direction: row;
         justify-content: space-between;
         border: none;
+        align-items: center;
+        transition: transform 0.3s;
 
         .slide {
           height: 70px;
@@ -156,3 +164,4 @@
     transition: opacity 0.5s;
   }
 }
+


### PR DESCRIPTION
Zadaniem jest stworzenie wersji mobilnych sekcji "Galeria".
Na telefonach pokazujemy tylko taby ze sliderem (na 100% szerokości containera), a ukrywamy duże zdjęcie z prawej. 
W sliderze miniaturek ma być tyle elementów, ile zmieści się w całości na danej szerokości ekranu.

Dodałem style oraz użyłem setVisibleSlides tak aby miniaturki wypełniały cały slider w każdej rozdzielczości, jeśli tylko sie mieszczą